### PR TITLE
Update README - fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Complete content that examines this code can be found at
 ## Related topics
 
 * [Developing Marble Maze, a UWP game in C++ and DirectX](https://docs.microsoft.com/windows/uwp/gaming/developing-marble-maze-a-windows-store-game-in-cpp-and-directx)
-* [Create a simple UWP game with DirectX](https://msdn.microsoft.com/library/windows/apps/mt210793.aspx)
+* [Create a simple UWP game with DirectX](https://docs.microsoft.com/en-us/windows/uwp/gaming/tutorial--create-your-first-uwp-directx-game)
 * [Game programming](https://docs.microsoft.com/windows/uwp/gaming/index)
 * [DirectX programming](https://docs.microsoft.com/windows/uwp/gaming/directx-programming)
 * [Direct3D Graphics Learning Guide](https://docs.microsoft.com/windows/uwp/graphics-concepts/)


### PR DESCRIPTION
The URL in Related Topics https://msdn.microsoft.com/library/windows/apps/mt210793.aspx to “Create a simple UWP game with DirectX” is broken.

Updated this link to https://docs.microsoft.com/en-us/windows/uwp/gaming/tutorial--create-your-first-uwp-directx-game which has the title "Create a simple Universal Windows Platform (UWP) game with DirectX"